### PR TITLE
CMake install fixes and header file handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.23)
 
 project(beman_execution26 VERSION 0.0.0 LANGUAGES CXX)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,21 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 
-set(BEMAN_OPTIONAL26_LIBRARY "beman_execution26")
+set(BEMAN_EXECUTION26_LIBRARY beman_execution26)
 
 include(GNUInstallDirs)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 set(EXAMPLES
   stop_token
 )
 
 foreach(EXAMPLE ${EXAMPLES})
-  add_executable(${EXAMPLE} "")
+  add_executable(${EXAMPLE})
   target_sources(${EXAMPLE} PRIVATE ${EXAMPLE}.cpp)
-  target_link_libraries(${EXAMPLE} "${BEMAN_EXECUTION26_LIBRARY}")
-  install(
-    TARGETS ${EXAMPLE}
-    EXPORT ${TARGETS_EXPORT_NAME}
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+  target_link_libraries(${EXAMPLE} PRIVATE ${BEMAN_EXECUTION26_LIBRARY})
 endforeach()

--- a/src/beman/execution26/CMakeLists.txt
+++ b/src/beman/execution26/CMakeLists.txt
@@ -92,6 +92,8 @@ target_sources(${TARGET_LIBRARY}
     ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/valid_completion_signatures.hpp
     ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/valid_specialization.hpp
 )
+get_property(DETAIL_HEADER_FILES TARGET ${TARGET_LIBRARY} PROPERTY HEADER_SET_${TARGET_LIBRARY}_detail_headers)
+source_group("Header Files\\detail" FILES ${DETAIL_HEADER_FILES})
 
 include(GNUInstallDirs)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/beman/execution26/CMakeLists.txt
+++ b/src/beman/execution26/CMakeLists.txt
@@ -3,34 +3,112 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # cmake-format: on
 
-set(TARGET_LIBRARY "beman_execution26")
+set(TARGET_LIBRARY beman_execution26)
 
 add_subdirectory(tests)
-add_library("${TARGET_LIBRARY}" STATIC "")
+add_library(${TARGET_LIBRARY} STATIC)
 
-target_sources("${TARGET_LIBRARY}" PRIVATE execution.cpp)
+target_sources(${TARGET_LIBRARY}
+    PRIVATE
+    execution.cpp
+    PUBLIC
+    FILE_SET ${TARGET_LIBRARY}_public_headers TYPE HEADERS
+    BASE_DIRS ${PROJECT_SOURCE_DIR}/include
+    FILES
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/execution.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/functional.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/stop_token.hpp
+    PUBLIC
+    FILE_SET ${TARGET_LIBRARY}_detail_headers TYPE HEADERS
+    BASE_DIRS ${PROJECT_SOURCE_DIR}/include
+    FILES
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/almost_scheduler.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/as_except_ptr.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/basic_receiver.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/basic_state.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/callable.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/call_result_t.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/check_type_alias_exist.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/common.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/completion_domain.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/completion_signature.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/completion_signatures.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/completion_tag.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/connect.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/continues_on.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/decayed_same_as.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/decayed_typeof.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/default_domain.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/default_impls.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/empty_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/env_of_t.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/env_type.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/forwarding_query.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/fwd_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_allocator.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_completion_scheduler.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_completion_signatures.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_domain.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_domain_late.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_scheduler.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/get_stop_token.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/impls_for.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/indices_for.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/inplace_stop_source.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/join_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/make_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/matching_sig.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/movable_value.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/never_stop_token.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/nostopstate.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/nothrow_callable.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/operation_state.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/queryable.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/query_with_default.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/receiver.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/schedule.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/scheduler.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/schedule_result_t.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sched_attrs.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sched_env.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sender.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sender_decompose.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sender_for.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/sender_in.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/set_error.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/set_stopped.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/set_value.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/simple_allocator.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/start.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/state_type.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/stoppable_source.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/stoppable_token.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/stop_callback_for_t.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/stop_source.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/transform_sender.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/unstoppable_token.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/valid_completion_for.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/valid_completion_signatures.hpp
+    ${PROJECT_SOURCE_DIR}/include/beman/execution26/detail/valid_specialization.hpp
+)
 
 include(GNUInstallDirs)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-target_include_directories(
-  "${TARGET_LIBRARY}"
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}>
-)
-
-install(
-  TARGETS "${TARGET_LIBRARY}"
-  EXPORT ${TARGETS_EXPORT_NAME}1
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
 string(TOLOWER ${CMAKE_PROJECT_NAME} CMAKE_LOWER_PROJECT_NAME)
 
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}
-  FILES_MATCHING
-  PATTERN "*.hpp")
+  TARGETS ${TARGET_LIBRARY}
+  EXPORT ${TARGETS_EXPORT_NAME}1
+  ARCHIVE DESTINATION lib/$<CONFIG>
+  FILE_SET ${TARGET_LIBRARY}_public_headers
+  FILE_SET ${TARGET_LIBRARY}_detail_headers
+)
+target_include_directories(${TARGET_LIBRARY} PUBLIC $<INSTALL_INTERFACE:include>)
 
-target_link_libraries("${TARGET_LIBRARY}")
+install(EXPORT ${TARGETS_EXPORT_NAME}1
+  FILE ${TARGET_LIBRARY}-config.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_LIBRARY}"
+  NAMESPACE ${TARGET_LIBRARY}::
+)

--- a/src/beman/execution26/tests/CMakeLists.txt
+++ b/src/beman/execution26/tests/CMakeLists.txt
@@ -60,14 +60,8 @@ list(APPEND execution_tests
     stopcallback-inplace-cons.pass
 )
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../../include)
 foreach(test ${execution_tests})
     add_executable(${test} ${test}.cpp)
-    target_include_directories(
-      "${test}"
-      PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../../include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}>
-    )
+    target_link_libraries(${test} PRIVATE ${TARGET_LIBRARY})
     add_test(NAME ${test} COMMAND $<TARGET_FILE:${test}>)
 endforeach()


### PR DESCRIPTION
This pull request mainly applies two fixes to the CMake script:

* The install target now correctly produces an install tree that can be consumed by downstream projects:
  ```cmake
  find_package(beman_execution26 REQUIRED)
  target_link_libraries(my_executable PRIVATE beman_execution26::beman_execution26)
  ```
* All header files are now listed in the CMakeLists.

I know that the second point is somewhat controversial, as many developers feel the need to maintain a list of header files in the `CMakeLists.txt` creates an unnecessary maintenance burden. However:
* This is required to properly display the header files on some IDEs (most prominently Visual Studio)
* It simplifies the installation routine, which can now use `FILE_SET`s for installing the headers

In principle, the explicit list of header files could be replaced by a glob expression. Although CMake [explicitly discourages this](https://cmake.org/cmake/help/latest/command/file.html#glob), as it will require to manually re-run CMake whenever the file structure changes, many projects are using this approach.