### PR TITLE
Fix cmake-tidy warnings on examples too

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,9 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "Makefile"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/linux.yml"
   pull_request:
@@ -18,6 +21,9 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "Makefile"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/linux.yml"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        # TODO: sanitizer: [debug, release, asan, usan, tsan]
-        sanitizer: [debug, release]
+        # TODO: sanitizer: [debug, release, asan, usan, tsan, lsan, msan]
+        preset: [debug, release]
         compiler: [g++-14, clang++-19]
 
     steps:
@@ -42,5 +42,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - name: Linux ${{ matrix.compiler }} ${{ matrix.sanitizer }}
-        run: CXX=${{ matrix.compiler }} make ${{ matrix.sanitizer }}
+      - name: Linux ${{ matrix.compiler }} ${{ matrix.preset }}
+        run: CXX=${{ matrix.compiler }} cmake --workflow --preset ${{ matrix.preset }}
+
+      - name: Linux ${{ matrix.compiler }} sanitizer
+        run: CXX=${{ matrix.compiler }} make all

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        sanitizer: [debug, release]
+        preset: [debug, release]
         # TODO: compiler: [g++, clang++-19]
         compiler: [g++, clang++-18]
 
@@ -49,10 +49,18 @@ jobs:
         run: |
           brew install llvm@19 || echo ignored
 
-      - name: macos clang++-18 ${{ matrix.sanitizer }}
+      - name: macos clang++-18 ${{ matrix.preset }}
         if: startsWith(matrix.compiler, 'clang')
-        run: CXX=$(brew --prefix llvm@18)/bin/clang++ make ${{ matrix.sanitizer }}
+        run: CXX=$(brew --prefix llvm@18)/bin/clang++ cmake --workflow --preset ${{ matrix.preset }}
 
-      - name: macos g++ ${{ matrix.sanitizer }}
+      - name: macos clang++-18 sanitizer
+        if: startsWith(matrix.compiler, 'clang')
+        run: CXX=$(brew --prefix llvm@18)/bin/clang++ make all
+
+      - name: macos g++ ${{ matrix.preset }}
         if: startsWith(matrix.compiler, 'g++')
-        run: CXX=${{ matrix.compiler }} make ${{ matrix.sanitizer }}
+        run: CXX=${{ matrix.compiler }} cmake --workflow --preset ${{ matrix.preset }}
+
+      - name: macos g++ sanitizer
+        if: startsWith(matrix.compiler, 'g++')
+        run: CXX=${{ matrix.compiler }} make all

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,9 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "Makefile"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/macos.yml"
   pull_request:
@@ -18,6 +21,9 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "Makefile"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/macos.yml"
 
@@ -61,6 +67,7 @@ jobs:
         if: startsWith(matrix.compiler, 'g++')
         run: CXX=${{ matrix.compiler }} cmake --workflow --preset ${{ matrix.preset }}
 
-      - name: macos g++ sanitizer
-        if: startsWith(matrix.compiler, 'g++')
-        run: CXX=${{ matrix.compiler }} make all
+      # TODO: fails with AppleClang 16.0.0 on CI!
+      # - name: macos g++ sanitizer
+      #   if: startsWith(matrix.compiler, 'g++')
+      #   run: CXX=${{ matrix.compiler }} make all

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,8 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/windows.yml"
   pull_request:
@@ -18,6 +20,8 @@ on:
       - "include/**"
       - "src/**"
       - "test/**"
+      - "cmake/**"
+      - "CMakePresets.json"
       - "CMakeLists.txt"
       - ".github/workflows/windows.yml"
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ MAKEFLAGS+= --warn-undefined-variables  # Warn when an undefined variable is ref
 SANITIZERS = release debug usan # TODO: lsan
 OS := $(shell /usr/bin/uname)
 ifeq ($(OS),Darwin)
-    SANITIZERS =+ tsan
+    SANITIZERS += tsan
 endif
 ifeq ($(OS),Linux)
-    SANITIZERS =+ asan # TODO: msan
+    SANITIZERS += asan # TODO: msan
 endif
 
 .PHONY: default doc run update check ce todo distclean clean codespell clang-tidy build test all format $(SANITIZERS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-SANITIZERS = release debug usan tsan lsan
+SANITIZERS = release debug usan tsan # TODO: lsan
 OS := $(uname)
 ifeq ($(OS),Linux)
     SANITIZERS =+ asan msan

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-SANITIZERS = release debug msan asan usan tsan
+SANITIZERS = release debug msan asan usan tsan lsan
 
 .PHONY: default doc run update check ce todo distclean clean codespell clang-tidy build test all format $(SANITIZERS)
 
@@ -83,8 +83,9 @@ check:
 		< $$h sed -n "/^ *# *include <Beman\//s@.*[</]Beman/\(.*\).hpp>.*@$$from \1@p"; \
 	done | tsort > /dev/null
 
+build/$(SANITIZER)/compile_commands.json: $(SANITIZER)
 clang-tidy: build/$(SANITIZER)/compile_commands.json
-	run-clang-tidy -p build/$(SANITIZER) tests
+	run-clang-tidy -p build/$(SANITIZER) tests examples
 
 codespell:
 	codespell -L statics,snd,copyable,cancelled
@@ -105,7 +106,7 @@ clean-doc:
 	$(RM) -r docs/html docs/latex
 
 clean: clean-doc
-	$(RM) -r $(BUILD) 
+	$(RM) -r $(BUILD)
 	$(RM) mkerr olderr *~
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,30 @@
 # Makefile
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-SANITIZERS = release debug usan tsan # TODO: lsan
-OS := $(uname)
+MAKEFLAGS+= --no-builtin-rules          # Disable the built-in implicit rules.
+MAKEFLAGS+= --warn-undefined-variables  # Warn when an undefined variable is referenced.
+
+SANITIZERS = release debug usan # TODO: lsan
+OS := $(shell /usr/bin/uname)
+ifeq ($(OS),Darwin)
+    SANITIZERS =+ tsan
+endif
 ifeq ($(OS),Linux)
     SANITIZERS =+ asan msan
 endif
 
 .PHONY: default doc run update check ce todo distclean clean codespell clang-tidy build test all format $(SANITIZERS)
 
-COMPILER=system
+SYSROOT   ?=
+TOOLCHAIN ?=
+
+COMPILER=c++
 CXX_BASE=$(CXX:$(dir $(CXX))%=%)
 ifeq ($(CXX_BASE),g++)
-    COMPILER=gcc
+    COMPILER=g++
 endif
 ifeq ($(CXX_BASE),clang++)
-    COMPILER=clang
+    COMPILER=clang++
 endif
 
 CXX_FLAGS = -g
@@ -24,7 +33,6 @@ SOURCEDIR = $(CURDIR)
 BUILDROOT = build
 BUILD     = $(BUILDROOT)/$(SANITIZER)
 EXAMPLE   = beman.execution26.examples.stop_token
-CMAKE_C_COMPILER=$(COMPILER)
 CMAKE_CXX_COMPILER=$(COMPILER)
 
 ifeq ($(SANITIZER),release)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(OS),Darwin)
     SANITIZERS =+ tsan
 endif
 ifeq ($(OS),Linux)
-    SANITIZERS =+ asan msan
+    SANITIZERS =+ asan # TODO: msan
 endif
 
 .PHONY: default doc run update check ce todo distclean clean codespell clang-tidy build test all format $(SANITIZERS)

--- a/examples/allocator.cpp
+++ b/examples/allocator.cpp
@@ -13,7 +13,7 @@ template <std::size_t Size>
 struct inline_resource : std::pmr::memory_resource {
     const char* name;
     explicit inline_resource(const char* name) : name(name) {}
-    std::byte  buffer[Size]{}; // NOLINT(hicpp-avoid-c-arrays)
+    std::byte  buffer[Size]{};      // NOLINT(hicpp-avoid-c-arrays)
     std::byte* next{+this->buffer}; // NOLINT(hicpp-no-array-decay)
 
     void* do_allocate(std::size_t size, std::size_t) override {
@@ -42,7 +42,8 @@ struct allocator_aware_fun {
     explicit allocator_aware_fun(F&& fun) : fun(std::forward<F>(fun)) {}
     allocator_aware_fun(const allocator_aware_fun& other, allocator_type allocator = {})
         : fun(other.fun), allocator(allocator) {}
-    allocator_aware_fun(allocator_aware_fun&& other) noexcept : fun(std::move(other.fun)), allocator(other.allocator) {}
+    allocator_aware_fun(allocator_aware_fun&& other) noexcept
+        : fun(std::move(other.fun)), allocator(other.allocator) {}
     allocator_aware_fun(allocator_aware_fun&& other, allocator_type allocator)
         : fun(std::move(other.fun)), allocator(allocator) {}
 

--- a/examples/allocator.cpp
+++ b/examples/allocator.cpp
@@ -12,9 +12,9 @@ namespace {
 template <std::size_t Size>
 struct inline_resource : std::pmr::memory_resource {
     const char* name;
-    inline_resource(const char* name) : name(name) {}
-    std::byte  buffer[Size];
-    std::byte* next{+this->buffer};
+    explicit inline_resource(const char* name) : name(name) {}
+    std::byte  buffer[Size]{}; // NOLINT(hicpp-avoid-c-arrays)
+    std::byte* next{+this->buffer}; // NOLINT(hicpp-no-array-decay)
 
     void* do_allocate(std::size_t size, std::size_t) override {
         std::cout << "allocating from=" << this->name << ", size=" << size << "\n";
@@ -29,6 +29,7 @@ struct inline_resource : std::pmr::memory_resource {
     bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override { return this == &other; }
 };
 
+// NOLINTBEGIN(hicpp-special-member-functions)
 template <typename Fun>
 struct allocator_aware_fun {
     using allocator_type = std::pmr::polymorphic_allocator<>;
@@ -38,10 +39,10 @@ struct allocator_aware_fun {
 
     template <typename F>
         requires std::same_as<std::remove_cvref_t<F>, std::remove_cvref_t<Fun>>
-    allocator_aware_fun(F&& fun) : fun(std::forward<F>(fun)) {}
+    explicit allocator_aware_fun(F&& fun) : fun(std::forward<F>(fun)) {}
     allocator_aware_fun(const allocator_aware_fun& other, allocator_type allocator = {})
         : fun(other.fun), allocator(allocator) {}
-    allocator_aware_fun(allocator_aware_fun&& other) : fun(std::move(other.fun)), allocator(other.allocator) {}
+    allocator_aware_fun(allocator_aware_fun&& other) noexcept : fun(std::move(other.fun)), allocator(other.allocator) {}
     allocator_aware_fun(allocator_aware_fun&& other, allocator_type allocator)
         : fun(std::move(other.fun)), allocator(allocator) {}
 
@@ -50,6 +51,7 @@ struct allocator_aware_fun {
         return this->fun(this->allocator, std::forward<Args>(args)...);
     }
 };
+// NOLINTEND(hicpp-special-member-functions)
 template <typename Fun>
 allocator_aware_fun(Fun&& fun) -> allocator_aware_fun<Fun>;
 
@@ -60,7 +62,7 @@ struct allocator_env {
 } // namespace
 
 auto main() -> int {
-    int  values[] = {1, 2, 3};
+    int  values[] = {1, 2, 3}; // NOLINT(hicpp-avoid-c-arrays)
     auto s{ex::just(std::span(values)) | ex::let_value(allocator_aware_fun([](auto alloc, std::span<int> v) {
                return ex::just(std::pmr::vector<int>(v.begin(), v.end(), alloc));
            })) |

--- a/examples/playground.cpp
+++ b/examples/playground.cpp
@@ -12,11 +12,8 @@ namespace ex = ::beman::execution26;
 
 int main()
 {
-    auto[result] = ex::sync_wait(
-        ex::when_all(
-            ex::just(std::string("hello, ")),
-            ex::just(std::string("world"))
-        ) | ex::then([](const auto& s1, const auto& s2){ return s1 + s2; })
-        ).value_or(std::tuple(std::string("oops")));
+    auto [result] = ex::sync_wait(ex::when_all(ex::just(std::string("hello, ")), ex::just(std::string("world"))) |
+                                  ex::then([](const auto& s1, const auto& s2) { return s1 + s2; }))
+                        .value_or(std::tuple(std::string("oops")));
     std::cout << "result='" << result << "'\n";
 }

--- a/examples/playground.cpp
+++ b/examples/playground.cpp
@@ -16,7 +16,7 @@ int main()
         ex::when_all(
             ex::just(std::string("hello, ")),
             ex::just(std::string("world"))
-        ) | ex::then([](auto s1, auto s2){ return s1 + s2; })
+        ) | ex::then([](const auto& s1, const auto& s2){ return s1 + s2; })
         ).value_or(std::tuple(std::string("oops")));
     std::cout << "result='" << result << "'\n";
 }

--- a/examples/sender-demo.cpp
+++ b/examples/sender-demo.cpp
@@ -47,7 +47,7 @@ static_assert(ex::sender_in<just_sender<std::pmr::string>>);
 
 int main() {
     auto j = just_sender{std::pmr::string("value")};
-    auto t = std::move(j) | ex::then([](std::pmr::string v) { return v + " then"; });
+    auto t = std::move(j) | ex::then([](const std::pmr::string& v) { return v + " then"; });
     auto w = ex::when_all(std::move(t));
     auto e = ex::detail::write_env(std::move(w),
                                    ex::detail::make_env(ex::get_allocator, std::pmr::polymorphic_allocator<>()));

--- a/examples/stop_token.cpp
+++ b/examples/stop_token.cpp
@@ -46,9 +46,9 @@ namespace exec = beman::execution26;
 // - std::print isn't available everywhere, yet. Let's try a simple
 //   placeholder.
 namespace {
-::std::mutex io_lock;
+::std::mutex        io_lock;
 void                print(std::string_view text, auto&&...) {
-    std::lock_guard const guard(io_lock);
+    const std::lock_guard guard(io_lock);
     ::std::cout << text;
 }
 
@@ -72,7 +72,7 @@ struct stop_callback_for_t {
 template <typename Token>
 auto inactive(const Token& token) -> void {
     ::std::latch        latch(1);
-    stop_callback_for_t const cb(token, [&latch] { latch.count_down(); });
+    const stop_callback_for_t cb(token, [&latch] { latch.count_down(); });
 
     latch.wait();
     print("inactive thread done (latch)\n");

--- a/examples/stopping.cpp
+++ b/examples/stopping.cpp
@@ -18,10 +18,11 @@ namespace ex = beman::execution26;
 
 // ----------------------------------------------------------------------------
 
+namespace {
 struct env {
     ex::inplace_stop_token token;
 
-    env(ex::inplace_stop_token token) : token(token) {}
+    env(ex::inplace_stop_token token) : token(token) {} // NOLINT(hicpp-explicit-conversions)
 
     auto query(const ex::get_stop_token_t&) const noexcept { return this->token; }
 };
@@ -73,6 +74,7 @@ struct receiver {
     auto set_error(auto&&) noexcept -> void {}
     auto set_stopped() noexcept -> void {}
 };
+} // namespace
 
 int main() {
     ex::inplace_stop_source source;

--- a/examples/when_all-cancel.cpp
+++ b/examples/when_all-cancel.cpp
@@ -109,6 +109,7 @@ struct eager {
         state(R&& r, S&& s) : outer_receiver(std::forward<R>(r)), inner_state() {
             inner_state.emplace(std::forward<S>(s), receiver{this});
         }
+        // TODO on next line: bugprone-unchecked-optional-access
         auto start() & noexcept -> void { ex::start((*this->inner_state).st); }
     };
     template <ex::receiver Receiver>
@@ -127,7 +128,6 @@ auto main() -> int {
 
     ex::inplace_stop_source source{};
     auto                    op{ex::connect(s, receiver{&source})};
-    (void)op;
     std::cout << "start\n";
     ex::start(op);
     std::cout << "started\n";


### PR DESCRIPTION
I reverted the `Makefile` as `sanitizer` driver and used it on **CI** in addition to simple generic `cmake workflow presets`.

misc-const-correctness
misc-use-anonymous-namespace
performance-unnecessary-value-param
hicpp-explicit-conversions
hicpp-member-init

- [ ] `TODO`: bugprone-unchecked-optional-access, and bugprone-exception-escape
- [ ] show lsan errors too https://github.com/beman-project/execution26/issues/79